### PR TITLE
bump evaluate to `0.3.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ bert_score==0.3.11
 colorama==0.4.5
 comet_ml==3.31.12
 datasets==2.4.0
-evaluate==0.2.2
+evaluate==0.3.0
 gensim==3.8.3
 hydra-core==1.2.0
 jieba==0.42.1


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.